### PR TITLE
Fix gemspec homepage uri error

### DIFF
--- a/client_scanner.gemspec
+++ b/client_scanner.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |spec|
   spec.license = "MIT"
   spec.required_ruby_version = ">= 3.1.0"
 
-  spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/RORingBBK/client_scanner"
   spec.metadata["changelog_uri"] = "https://github.com/RORingBBK/client_scanner/blob/main/CHANGELOG.md"
 


### PR DESCRIPTION
Fixes `homepage_uri` metadata not being a string in gem specifications